### PR TITLE
🤖 AutoFix: Updated the spring-javaformat-maven-plugin version to a stable release to avoid the IndexOutOfBoundsException. [XML]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <lifecycle-mapping>1.0.0</lifecycle-mapping>
     <maven-checkstyle.version>3.6.0</maven-checkstyle.version>
     <nohttp-checkstyle.version>0.0.11</nohttp-checkstyle.version>
-    <spring-format.version>0.0.45</spring-format.version>
+    <spring-format.version>0.0.46</spring-format.version>
 
   </properties>
 


### PR DESCRIPTION
## 🤖 Correction Automatique par IA

### 📋 Informations
- **Fichier corrigé:** `pom.xml`
- **Langage:** XML
- **Build:** job/lsa/job/Workspace-Caching/job/Example/job/Compilation-Error-Petclinic/456/consoleText #456
- **Plateforme:** JENKINS
- **Timestamp:** 04/07/2025 19:57:29

### 🔍 Analyse
- **Type d'erreur:** build_failure
- **Cause racine:** The spring-javaformat-maven-plugin version 0.0.45 is causing an IndexOutOfBoundsException during formatting.
- **Confiance:** high

### 💡 Solution Appliquée
Updated the spring-javaformat-maven-plugin version to a stable release to avoid the IndexOutOfBoundsException.

### 📊 Détails Techniques
- **Lignes modifiées:** Non spécifié
- **Type de correction:** Non spécifié

### 🔗 Références
- **Build Jenkins:** [Voir le build](https://core.cloudbees.guru/shared-demos/job/lsa/job/Workspace-Caching/job/Example/job/Compilation-Error-Petclinic/456/)
- **IA utilisée:** deepseek-r1
- **Version AutoFix:** v2.0

---
*Cette Pull Request a été générée automatiquement par n8n AutoFix.*